### PR TITLE
Change pom.xml to use https for oxygen maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <repository>
       <id>public</id>
       <name>oXygen public artifacts</name>
-      <url>http://www.oxygenxml.com/maven</url>
+      <url>https://www.oxygenxml.com/maven</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
Changed the url for the maven repo for oxygenxml.com from http: to https: because the build was failing. After this change, the build completed successfully

mvn install was failing with the following message:

```
bash$ mvn install
...
[ERROR] Failed to execute goal on project oxygen-plugin-workspace-access Could
not resolve dependencies for project
com.oxygenxml.samples:oxygen-plugin-workspace-access:jar:1.0: Could not transfer
artifact com.oxygenxml:oxygen-sandbox:jar:21.1.0.2 from/to public
(http://www.oxygenxml.com/maven): GET request of:
com/oxygenxml/oxygen-sandbox/21.1.0.2/oxygen-sandbox-21.1.0.2.jar from public
failed: Connection reset -> [Help 1]
```